### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/inthehack/noshell/compare/noshell-v0.1.1...noshell-v0.2.0) - 2025-03-30
+
+### Added
+
+- add support for flag to id lookup
+- *(parser)* add get_one and get_many helpers on ParsedArgs
+- *(parser)* add tokens and values iterators to lexer
+- *(macros)* add check for short and long flags
+- *(macros)* add limit arg to noshell attribute
+- *(macros)* add attribute parser
+- *(macros)* add multiple option and vec variants of parsers
+
+### Fixed
+
+- *(macros)* use correct limit for parsed args and arg parsers
+- use idiomatic parser implementations
+- use parser error instead of undefined
+- *(parser)* improve robustess of token distinction
+- *(parser)* don't forget to dereference sometimes
+
+### Other
+
+- *(macros)* clean up noshell limit arg parsing
+- apply code formatting
+- *(macros)* remove span from attribute

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "noshell"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "defmt",
  "googletest",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "noshell-macros"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "darling",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "noshell-parser"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "defmt",
  "googletest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 authors = ["Julien Peeters <inthehack@mountainhacks.org>"]
 license = "Apache-2.0 OR MIT"

--- a/noshell/Cargo.toml
+++ b/noshell/Cargo.toml
@@ -11,8 +11,8 @@ description.workspace = true
 readme.workspace = true
 
 [dependencies]
-noshell-macros = { path = "../noshell-macros", version = "0.1.1" }
-noshell-parser = { path = "../noshell-parser", version = "0.1.1" }
+noshell-macros = { path = "../noshell-macros", version = "0.2.0" }
+noshell-parser = { path = "../noshell-parser", version = "0.2.0" }
 
 defmt = { workspace = true, optional = true }
 thiserror.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `noshell-parser`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)
* `noshell-macros`: 0.1.1 -> 0.2.0
* `noshell`: 0.1.1 -> 0.2.0 (✓ API compatible changes)

### ⚠ `noshell-parser` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Error::InvalidArgument 0 -> 1 in /tmp/.tmp4qX0zW/noshell/noshell-parser/src/parser.rs:22
  variant Error::MissingArgument 1 -> 2 in /tmp/.tmp4qX0zW/noshell/noshell-parser/src/parser.rs:27
  variant Error::InvalidArgument 0 -> 1 in /tmp/.tmp4qX0zW/noshell/noshell-parser/src/parser.rs:22
  variant Error::MissingArgument 1 -> 2 in /tmp/.tmp4qX0zW/noshell/noshell-parser/src/parser.rs:27

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant Token:Flag in /tmp/.tmp4qX0zW/noshell/noshell-parser/src/lexer.rs:34

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Token::ShortFlag, previously in file /tmp/.tmpVNKdEN/noshell-parser/src/lexer.rs:8
  variant Token::LongFlag, previously in file /tmp/.tmpVNKdEN/noshell-parser/src/lexer.rs:11

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/inherent_method_missing.ron

Failed in:
  ParsedArgs::get, previously in file /tmp/.tmpVNKdEN/noshell-parser/src/parser.rs:49
  ParsedArgs::is_enabled, previously in file /tmp/.tmpVNKdEN/noshell-parser/src/parser.rs:81
  ParsedArgs::get, previously in file /tmp/.tmpVNKdEN/noshell-parser/src/parser.rs:49
  ParsedArgs::is_enabled, previously in file /tmp/.tmpVNKdEN/noshell-parser/src/parser.rs:81

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/method_parameter_count_changed.ron

Failed in:
  noshell_parser::parser::ParsedArgs::parse now takes 2 parameters instead of 1, in /tmp/.tmp4qX0zW/noshell/noshell-parser/src/parser.rs:44
  noshell_parser::ParsedArgs::parse now takes 2 parameters instead of 1, in /tmp/.tmp4qX0zW/noshell/noshell-parser/src/parser.rs:44

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  noshell_parser::parser::ParsedArgs::parse takes 0 generic types instead of 1, in /tmp/.tmp4qX0zW/noshell/noshell-parser/src/parser.rs:44
  noshell_parser::ParsedArgs::parse takes 0 generic types instead of 1, in /tmp/.tmp4qX0zW/noshell/noshell-parser/src/parser.rs:44

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_missing.ron

Failed in:
  struct noshell_parser::lexer::Lexer, previously in file /tmp/.tmpVNKdEN/noshell-parser/src/lexer.rs:21
  struct noshell_parser::Lexer, previously in file /tmp/.tmpVNKdEN/noshell-parser/src/lexer.rs:21
```

<details><summary><i><b>Changelog</b></i></summary><p>



## `noshell`

<blockquote>

## [0.2.0](https://github.com/inthehack/noshell/compare/noshell-v0.1.1...noshell-v0.2.0) - 2025-03-30

### Added

- add support for flag to id lookup
- *(parser)* add get_one and get_many helpers on ParsedArgs
- *(parser)* add tokens and values iterators to lexer
- *(macros)* add check for short and long flags
- *(macros)* add limit arg to noshell attribute
- *(macros)* add attribute parser
- *(macros)* add multiple option and vec variants of parsers

### Fixed

- *(macros)* use correct limit for parsed args and arg parsers
- use idiomatic parser implementations
- use parser error instead of undefined
- *(parser)* improve robustess of token distinction
- *(parser)* don't forget to dereference sometimes

### Other

- *(macros)* clean up noshell limit arg parsing
- apply code formatting
- *(macros)* remove span from attribute
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).