### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/inthehack/noshell/compare/v0.2.0...v0.3.0) - 2026-01-26
+
+### Added
+
+- handling of one and many argument values
+- add prompt and readline handling
+- add posix word lexer
+- use iterators while parsing
+- add shell runner (wip)
+- add static command definitions
+- better error handling in proc-macros
+
+### Fixed
+
+- handling of control events in readline ([#4](https://github.com/inthehack/noshell/pull/4))
+- update to follow new parsed arg impl
+
+### Other
+
+- update cargo deps
+- add integration tests with parser
+- fix noterm dependency
+- move library tests to separate module file
+- rename module line by cmdline
+- lint
+- add test for readline
+- add feature request in readme
+- remove redundant pattern matching
+
 ## [0.2.0](https://github.com/inthehack/noshell/compare/noshell-v0.1.1...noshell-v0.2.0) - 2025-03-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "noshell"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "defmt 0.3.100",
  "futures",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "noshell-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "darling",
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "noshell-parser"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "defmt 0.3.100",
  "googletest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["Julien Peeters <inthehack@mountainhacks.org>"]
 license = "Apache-2.0 OR MIT"

--- a/noshell/Cargo.toml
+++ b/noshell/Cargo.toml
@@ -25,8 +25,8 @@ thiserror = { workspace = true }
 
 noterm = { version = "0.1.1" }
 
-noshell-macros = { path = "../noshell-macros", version = "0.2.0" }
-noshell-parser = { path = "../noshell-parser", version = "0.2.0", optional = true }
+noshell-macros = { path = "../noshell-macros", version = "0.3.0" }
+noshell-parser = { path = "../noshell-parser", version = "0.3.0", optional = true }
 
 [dev-dependencies]
 insta = "1.46.0"


### PR DESCRIPTION



## 🤖 New release

* `noshell-parser`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `noshell-macros`: 0.2.0 -> 0.3.0
* `noshell`: 0.2.0 -> 0.3.0 (✓ API compatible changes)

### ⚠ `noshell-parser` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Error::MissingArgument 2 -> 3 in /tmp/.tmpoKqMvV/noshell/noshell-parser/src/parser.rs:38
  variant Error::OutOfMemory 3 -> 4 in /tmp/.tmpoKqMvV/noshell/noshell-parser/src/parser.rs:42
  variant Error::MissingArgument 2 -> 3 in /tmp/.tmpoKqMvV/noshell/noshell-parser/src/parser.rs:38
  variant Error::OutOfMemory 3 -> 4 in /tmp/.tmpoKqMvV/noshell/noshell-parser/src/parser.rs:42

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  ParsedArgs::parse, previously in file /tmp/.tmphvwTlg/noshell-parser/src/parser.rs:44
  ParsedArgs::try_parse, previously in file /tmp/.tmphvwTlg/noshell-parser/src/parser.rs:49
  ParsedArgs::parse, previously in file /tmp/.tmphvwTlg/noshell-parser/src/parser.rs:44
  ParsedArgs::try_parse, previously in file /tmp/.tmphvwTlg/noshell-parser/src/parser.rs:49

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct noshell_parser::lexer::Values, previously in file /tmp/.tmphvwTlg/noshell-parser/src/lexer.rs:178
  struct noshell_parser::lexer::Tokens, previously in file /tmp/.tmphvwTlg/noshell-parser/src/lexer.rs:99
  struct noshell_parser::Tokens, previously in file /tmp/.tmphvwTlg/noshell-parser/src/lexer.rs:99

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_missing.ron

Failed in:
  trait noshell_parser::lexer::IntoTokens, previously in file /tmp/.tmphvwTlg/noshell-parser/src/lexer.rs:158
```

<details><summary><i><b>Changelog</b></i></summary><p>



## `noshell`

<blockquote>

## [0.3.0](https://github.com/inthehack/noshell/compare/v0.2.0...v0.3.0) - 2026-01-26

### Added

- handling of one and many argument values
- add prompt and readline handling
- add posix word lexer
- use iterators while parsing
- add shell runner (wip)
- add static command definitions
- better error handling in proc-macros

### Fixed

- handling of control events in readline ([#4](https://github.com/inthehack/noshell/pull/4))
- update to follow new parsed arg impl

### Other

- update cargo deps
- add integration tests with parser
- fix noterm dependency
- move library tests to separate module file
- rename module line by cmdline
- lint
- add test for readline
- add feature request in readme
- remove redundant pattern matching
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).