### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/inthehack/noshell/compare/v0.3.0...v0.4.0) - 2026-02-19
+
+### Added
+
+- display error message on unexpected tokens
+- refine error handling and enumeration
+- make console I/O internally mutable
+- clearer handling of error in console
+- better segmentation of error in console
+- add command handler in console
+- expose console as top-level type
+- expose console writer as erased type
+- add console basic implementation
+- make line error comparable
+- capture an error when input is invalid
+- [**breaking**] return error in case of words splitting fails
+- [**breaking**] simplify prompt api
+
+### Fixed
+
+- prevent incorrect backtracking in quoted-string parsers
+
+### Other
+
+- fix missing version in local dependencies
+- clean up dependencies
+- enable integration tests only if required feature is set
+- update version constraint on noterm dependency
+- update noterm dependency
+- [**breaking**] change cmdline module name to line
+- move tests to independent file
+- remove inlining of function
+- use whitespace check from core lib
+- update noterm dependency
+- rename word iterator
+
 ## [0.3.0](https://github.com/inthehack/noshell/compare/v0.2.0...v0.3.0) - 2026-01-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "noshell"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "defmt 0.3.100",
  "futures",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "noshell-macros"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "darling",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "noshell-parser"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "defmt 0.3.100",
  "googletest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["Julien Peeters <inthehack@mountainhacks.org>"]
 license = "Apache-2.0 OR MIT"

--- a/noshell/Cargo.toml
+++ b/noshell/Cargo.toml
@@ -24,8 +24,8 @@ itertools = { version = "0.14.0", default-features = false }
 nom = { workspace = true }
 thiserror = { workspace = true }
 
-noshell-macros = { path = "../noshell-macros", version = "0.3.0" }
-noshell-parser = { path = "../noshell-parser", version = "0.3.0", optional = true }
+noshell-macros = { path = "../noshell-macros", version = "0.4.0" }
+noshell-parser = { path = "../noshell-parser", version = "0.4.0", optional = true }
 
 noterm = { version = "^0.2.3" }
 


### PR DESCRIPTION



## 🤖 New release

* `noshell-parser`: 0.3.0 -> 0.4.0
* `noshell-macros`: 0.3.0 -> 0.4.0
* `noshell`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `noshell` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum noshell::cmdline::Error, previously in file /tmp/.tmpx45VE2/noshell/src/cmdline.rs:27

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function noshell::cmdline::lexer::split, previously in file /tmp/.tmpx45VE2/noshell/src/cmdline/lexer.rs:14
  function noshell::cmdline::readline, previously in file /tmp/.tmpx45VE2/noshell/src/cmdline.rs:49

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod noshell::cmdline::lexer, previously in file /tmp/.tmpx45VE2/noshell/src/cmdline/lexer.rs:1
  mod noshell::cmdline::prompt, previously in file /tmp/.tmpx45VE2/noshell/src/cmdline/prompt.rs:1
  mod noshell::cmdline, previously in file /tmp/.tmpx45VE2/noshell/src/cmdline.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct noshell::cmdline::prompt::Prompt, previously in file /tmp/.tmpx45VE2/noshell/src/cmdline/prompt.rs:12
  struct noshell::cmdline::Prompt, previously in file /tmp/.tmpx45VE2/noshell/src/cmdline/prompt.rs:12
```

<details><summary><i><b>Changelog</b></i></summary><p>



## `noshell`

<blockquote>

## [0.4.0](https://github.com/inthehack/noshell/compare/v0.3.0...v0.4.0) - 2026-02-19

### Added

- display error message on unexpected tokens
- refine error handling and enumeration
- make console I/O internally mutable
- clearer handling of error in console
- better segmentation of error in console
- add command handler in console
- expose console as top-level type
- expose console writer as erased type
- add console basic implementation
- make line error comparable
- capture an error when input is invalid
- [**breaking**] return error in case of words splitting fails
- [**breaking**] simplify prompt api

### Fixed

- prevent incorrect backtracking in quoted-string parsers

### Other

- fix missing version in local dependencies
- clean up dependencies
- enable integration tests only if required feature is set
- update version constraint on noterm dependency
- update noterm dependency
- [**breaking**] change cmdline module name to line
- move tests to independent file
- remove inlining of function
- use whitespace check from core lib
- update noterm dependency
- rename word iterator
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).