### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/inthehack/noshell/compare/v0.4.0...v0.4.1) - 2026-02-25
+
+### Added
+
+- make command execution asynchronous
+
 ## [0.4.0](https://github.com/inthehack/noshell/compare/v0.3.0...v0.4.0) - 2026-02-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "noshell"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "defmt 0.3.100",
  "futures",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "noshell-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "darling",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "noshell-parser"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "defmt 0.3.100",
  "googletest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["Julien Peeters <inthehack@mountainhacks.org>"]
 license = "Apache-2.0 OR MIT"

--- a/noshell/Cargo.toml
+++ b/noshell/Cargo.toml
@@ -24,8 +24,8 @@ itertools = { version = "0.14.0", default-features = false }
 nom = { workspace = true }
 thiserror = { workspace = true }
 
-noshell-macros = { path = "../noshell-macros", version = "0.4.0" }
-noshell-parser = { path = "../noshell-parser", version = "0.4.0", optional = true }
+noshell-macros = { path = "../noshell-macros", version = "0.4.1" }
+noshell-parser = { path = "../noshell-parser", version = "0.4.1", optional = true }
 
 noterm = { version = "^0.2.3" }
 


### PR DESCRIPTION



## 🤖 New release

* `noshell-parser`: 0.4.0 -> 0.4.1
* `noshell-macros`: 0.4.0 -> 0.4.1
* `noshell`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



## `noshell`

<blockquote>

## [0.4.1](https://github.com/inthehack/noshell/compare/v0.4.0...v0.4.1) - 2026-02-25

### Added

- make command execution asynchronous
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).