### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/inthehack/noshell/compare/v0.4.1...v0.5.0) - 2026-02-27
+
+### Added
+
+- [**breaking**] use closure handler to process commands instead of Command
+
 ## [0.4.1](https://github.com/inthehack/noshell/compare/v0.4.0...v0.4.1) - 2026-02-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "noshell"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "defmt 0.3.100",
  "futures",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "noshell-macros"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "darling",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "noshell-parser"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "defmt 0.3.100",
  "googletest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 authors = ["Julien Peeters <inthehack@mountainhacks.org>"]
 license = "Apache-2.0 OR MIT"

--- a/noshell/Cargo.toml
+++ b/noshell/Cargo.toml
@@ -24,8 +24,8 @@ itertools = { version = "0.14.0", default-features = false }
 nom = { workspace = true }
 thiserror = { workspace = true }
 
-noshell-macros = { path = "../noshell-macros", version = "0.4.1" }
-noshell-parser = { path = "../noshell-parser", version = "0.4.1", optional = true }
+noshell-macros = { path = "../noshell-macros", version = "0.5.0" }
+noshell-parser = { path = "../noshell-parser", version = "0.5.0", optional = true }
 
 noterm = { version = "^0.2.3" }
 


### PR DESCRIPTION



## 🤖 New release

* `noshell-parser`: 0.4.1 -> 0.5.0
* `noshell-macros`: 0.4.1 -> 0.5.0
* `noshell`: 0.4.1 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `noshell` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  Console::register, previously in file /tmp/.tmpXWRqgk/noshell/src/console.rs:96
  Console::register_unchecked, previously in file /tmp/.tmpXWRqgk/noshell/src/console.rs:106
  Console::register, previously in file /tmp/.tmpXWRqgk/noshell/src/console.rs:96
  Console::register_unchecked, previously in file /tmp/.tmpXWRqgk/noshell/src/console.rs:106

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  noshell::console::Console::process now takes 1 parameters instead of 0, in /tmp/.tmpb4HY6Q/noshell/noshell/src/console.rs:109
  noshell::Console::process now takes 1 parameters instead of 0, in /tmp/.tmpb4HY6Q/noshell/noshell/src/console.rs:109

--- failure method_receiver_ref_became_mut: method receiver changed from immutable to mutable reference ---

Description:
A method's receiver changed from an immutable reference to a mutable one.
        ref: https://doc.rust-lang.org/reference/items/associated-items.html#methods
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_receiver_ref_became_mut.ron

Failed in:
  noshell::console::Console::writer now takes &mut Self, not &Self, in /tmp/.tmpb4HY6Q/noshell/noshell/src/console.rs:101
  noshell::Console::writer now takes &mut Self, not &Self, in /tmp/.tmpb4HY6Q/noshell/noshell/src/console.rs:101

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  noshell::console::Console::process takes 2 generic types instead of 0, in /tmp/.tmpb4HY6Q/noshell/noshell/src/console.rs:109
  noshell::Console::process takes 2 generic types instead of 0, in /tmp/.tmpb4HY6Q/noshell/noshell/src/console.rs:109

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod noshell::command, previously in file /tmp/.tmpXWRqgk/noshell/src/command.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct noshell::command::Command, previously in file /tmp/.tmpXWRqgk/noshell/src/command.rs:13
  struct noshell::command::UnitFuture, previously in file /tmp/.tmpXWRqgk/noshell/src/command.rs:36
  struct noshell::console::ConsoleWriter, previously in file /tmp/.tmpXWRqgk/noshell/src/console.rs:182
```

<details><summary><i><b>Changelog</b></i></summary><p>



## `noshell`

<blockquote>

## [0.5.0](https://github.com/inthehack/noshell/compare/v0.4.1...v0.5.0) - 2026-02-27

### Added

- [**breaking**] use closure handler to process commands instead of Command
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).